### PR TITLE
Add php 7.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 report.lcov
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
   - 5.6
-  - '7'
+  - 7.0
+  - 7.1
   - hhvm
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.6.0",
         "yosymfony/toml": "~0.3",
-        "easyframework/collections": "~6.0",
+        "easyframework/collections": "^6.0 | ^7.0",
         "league/climate": "~3.2",
         "mustache/mustache": "~2.11",
         "eloquent/pathogen": "~0.6"


### PR DESCRIPTION
Allow the usage of `easyframework/collections` in version 7.0.0 for PHP 7.1 compatibility.